### PR TITLE
Fix .ts path handling in CLI run/list/save_ast (issue #41)

### DIFF
--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -3,6 +3,7 @@ use miette::IntoDiagnostic;
 use termcolor::Color;
 
 use crate::{cli::ListArgs, shell::Shell};
+use crate::path_utils::is_ts_path;
 
 use super::utils;
 
@@ -40,13 +41,13 @@ pub async fn list(shell: &mut Shell, args: ListArgs) -> miette::Result<()> {
             .into_diagnostic()?
     } else {
         // For TypeScript files, check if we need to generate the AST
-        let pipeline_path = if path.ends_with(".ts") {
+        let pipeline_path = if is_ts_path(&path) {
             path.clone()
         } else {
             path.join("pipeline.ts")
         };
 
-        let pipeline_json_path = if path.ends_with(".ts") {
+        let pipeline_json_path = if is_ts_path(&path) {
             path.parent().unwrap().join("pipeline.json")
         } else {
             path.join("pipeline.json")

--- a/cli/src/command/run.rs
+++ b/cli/src/command/run.rs
@@ -30,6 +30,7 @@ use tokio::{io::AsyncReadExt as _, sync::RwLock};
 
 use crate::{
     cli::{DebugDumpAstArgs, RunArgs},
+    path_utils::is_ts_path,
     shell::Shell,
 };
 
@@ -707,7 +708,7 @@ pub async fn run(shell: &mut Shell, mut args: RunArgs) -> miette::Result<()> {
         }
     } else {
         // For TypeScript files, prepare the environment (sync + type check)
-        let pipeline_path = if path.ends_with(".ts") {
+        let pipeline_path = if is_ts_path(&path) {
             path.clone()
         } else {
             path.join("pipeline.ts")

--- a/cli/src/deno_rt.rs
+++ b/cli/src/deno_rt.rs
@@ -3,6 +3,8 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
+use crate::path_utils::is_ts_path;
+
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error("Deno execution failed: {0}")]
@@ -121,7 +123,7 @@ console.log(JSON.stringify(result));
 
 pub fn save_ast(path: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<(), Error> {
     let mut path = path.as_ref().to_path_buf();
-    if !path.ends_with(".ts") {
+    if !is_ts_path(&path) {
         path = path.join("pipeline.ts");
     }
     let input = std::fs::read_to_string(path)?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -16,6 +16,7 @@ use shell::Shell;
 mod cli;
 mod command;
 mod deno_rt;
+mod path_utils;
 mod shell;
 
 pub async fn run_cli() -> miette::Result<()> {

--- a/cli/src/path_utils.rs
+++ b/cli/src/path_utils.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+pub fn is_ts_path(path: &Path) -> bool {
+    path.extension().map(|x| x.as_encoded_bytes()) == Some(b"ts")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ts_path;
+    use std::path::Path;
+
+    #[test]
+    fn detects_ts_file_extension() {
+        assert!(is_ts_path(Path::new("pipeline.ts")));
+    }
+
+    #[test]
+    fn rejects_non_ts_extension() {
+        assert!(!is_ts_path(Path::new("pipeline.json")));
+    }
+
+    #[test]
+    fn rejects_path_with_ts_directory_name() {
+        assert!(!is_ts_path(Path::new("tools/pipeline.ts/pipeline")));
+    }
+
+    #[test]
+    fn detects_ts_with_parent_dirs() {
+        assert!(is_ts_path(Path::new("tools/grammarcheckers/pipeline.ts")));
+    }
+}


### PR DESCRIPTION
## Summary
Fix CLI handling of direct .ts paths by using extension-aware checks instead of string-like path suffix checks.

## Root cause
The CLI used `Path::ends_with(".ts")`, which matches path components, not filename suffixes. This could produce invalid paths like `pipeline.ts/pipeline.ts` and fail with `Not a directory`.

## Changes
- Add shared helper `is_ts_path` in `cli/src/path_utils.rs`
- Use helper in:
  - `cli/src/command/run.rs`
  - `cli/src/command/list.rs`
  - `cli/src/deno_rt.rs`
- Add unit tests in `cli/src/path_utils.rs` to prevent regression

## Validation
- `cargo check -p divvun-runtime-cli` passes
- `cargo check -p divvun-runtime-cli --tests` passes
- Full `cargo test -p divvun-runtime-cli` still hits existing environment-specific linker issues (missing `DRT_*` symbols), unrelated to this change

Fixes #41
